### PR TITLE
fix: changing javadoc property

### DIFF
--- a/modules/examples/pom.xml
+++ b/modules/examples/pom.xml
@@ -14,7 +14,7 @@
     <name>Code Examples</name>
 
     <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.javadoc.skip>false</maven.javadoc.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## PR summary
Changed <maven.javadoc.skip>false</maven.javadoc.skip> in example module to build javadoc for example.


